### PR TITLE
Max IPv6 address length is 45 characters, not 16

### DIFF
--- a/gomilter.go
+++ b/gomilter.go
@@ -212,12 +212,12 @@ func Go_xxfi_connect(ctx *C.SMFICTX, hostname *C.char, hostaddr *C._SOCK_ADDR) C
 
 	} else if hostaddr.sa_family == C.AF_INET6 {
 		sa_in := (*C.struct_sockaddr_in6)(unsafe.Pointer(hostaddr))
-		var dst = make([]byte, 16)
+		var dst = make([]byte, 45)
 		C.inet_ntop(
 			C.int(hostaddr.sa_family),
 			unsafe.Pointer(&sa_in.sin6_addr),
 			(*C.char)(unsafe.Pointer(&dst)),
-			16)
+			45)
 
 		ip = net.ParseIP(C.GoString((*C.char)(unsafe.Pointer(&dst))))
 	} else {


### PR DESCRIPTION
The idea was to reserve 16 bytes for an IPv6 address. But given that a human representation is used rather than a 128 bit integer, we need 45 characters at most.

I had originally only tested this with ::1 as IP - which worked. But when moving it to production, where Google et all tried to communicate from IP's other than localhost, it failed miserably. This fixes that.

(btw, nice changes on the logging interface!)
