### PR TITLE
Linker path for Debian/Ubuntu

### DIFF
--- a/gomilter.go
+++ b/gomilter.go
@@ -14,7 +14,7 @@ package gomilter
 
 /*
 
-#cgo LDFLAGS: -lmilter
+#cgo LDFLAGS: -L/usr/lib/libmilter -lmilter
 
 #include <stdlib.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Libmilter is installed in /usr/lib/libmilter on Debian and Ubuntu
systems. Added additional Linker path for cgo.

Credits go to: https://github.com/davrux/gomilter/commit/f724fd7bcb370b4625adf70aa178f9ffb1917c1e
