### PR TITLE
Add support for the Data() callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Milter callbacks are added by implementing methods for the struct with matching 
 * Helo
 * EnvFrom
 * EnvRcpt
+* Data
 * Header
 * Eoh
 * Body

--- a/filter.c
+++ b/filter.c
@@ -32,6 +32,10 @@ void setHeader(struct smfiDesc *smfilter) {
   smfilter->xxfi_header = &Go_xxfi_header;
 }
 
+void setData(struct smfiDesc *smfilter) {
+  smfilter->xxfi_data = &Go_xxfi_data;
+}
+
 void setEoh(struct smfiDesc *smfilter) {
   smfilter->xxfi_eoh = &Go_xxfi_eoh;
 }

--- a/filter.h
+++ b/filter.h
@@ -5,16 +5,17 @@ This projected is licensed under the terms of the MIT License.
 
 // Set Callback functions in smfiDesc struct
 extern void makesmfilter(struct smfiDesc *smfilter);
+extern void setAbort(struct smfiDesc *smfilter);
+extern void setBody(struct smfiDesc *smfilter);
+extern void setClose(struct smfiDesc *smfilter);
 extern void setConnect(struct smfiDesc *smfilter);
-extern void setHelo(struct smfiDesc *smfilter);
+extern void setData(struct smfiDesc *smfilter);
 extern void setEnvFrom(struct smfiDesc *smfilter);
 extern void setEnvRcpt(struct smfiDesc *smfilter);
-extern void setHeader(struct smfiDesc *smfilter);
 extern void setEoh(struct smfiDesc *smfilter);
-extern void setBody(struct smfiDesc *smfilter);
 extern void setEom(struct smfiDesc *smfilter);
-extern void setAbort(struct smfiDesc *smfilter);
-extern void setClose(struct smfiDesc *smfilter);
+extern void setHeader(struct smfiDesc *smfilter);
+extern void setHelo(struct smfiDesc *smfilter);
 
 // Utility functions for things that we can't do in Go
 

--- a/gomilter.go
+++ b/gomilter.go
@@ -70,6 +70,21 @@ const (
 	SETSYMLIST  = 0x00000100 // 100000000
 )
 
+// What the MTA can send/filter wants in protocol
+const (
+	SMFIP_NOCONNECT = 0x00000001   // MTA should not send connect info
+	SMFIP_NOHELO    = 0x00000002   // MTA should not send HELO info
+	SMFIP_NOMAIL    = 0x00000004   // MTA should not send MAIL info
+	SMFIP_NORCPT    = 0x00000008   // MTA should not send RCPT info
+	SMFIP_NOBODY    = 0x00000010   // MTA should not send body
+	SMFIP_NOHDRS    = 0x00000020   // MTA should not send headers
+	SMFIP_NOEOH     = 0x00000040   // MTA should not send EOH
+	SMFIP_NR_HDR    = 0x00000080   // No reply for headers
+	SMFIP_NOHREPL   = SMFIP_NR_HDR // No reply for headers
+	SMFIP_NOUNKNOWN = 0x00000100   // MTA should not send unknown commands
+	SMFIP_NODATA    = 0x00000200   // MTA should not send DATA
+)
+
 // Interface that must be implemented in order to use gomilter
 type Milter interface {
 	GetFilterName() string

--- a/gomilter.go
+++ b/gomilter.go
@@ -129,6 +129,10 @@ type checkForHeader interface {
 	Header(ctx uintptr, headerf, headerv string) (sfsistat int8)
 }
 
+type checkForData interface {
+	Data(ctx uintptr) (sfsistat int8)
+}
+
 type checkForEoh interface {
 	Eoh(ctx uintptr) (sfsistat int8)
 }
@@ -271,6 +275,16 @@ func Go_xxfi_envrcpt(ctx *C.SMFICTX, argv **C.char) C.sfsistat {
 	code := m.EnvRcpt(ctx2int(ctx), cStringArrayToSlice(argv))
 	if milter.GetDebug() {
 		logger.Printf("EnvRcpt callback returned: %d\n", code)
+	}
+	return C.sfsistat(code)
+}
+
+//export Go_xxfi_data
+func Go_xxfi_data(ctx *C.SMFICTX) C.sfsistat {
+	m := milter.(checkForData)
+	code := m.Data(ctx2int(ctx))
+	if milter.GetDebug() {
+		logger.Printf("Data callback returned: %d\n", code)
 	}
 	return C.sfsistat(code)
 }
@@ -667,6 +681,17 @@ func Run(amilter Milter) int {
 	} else {
 		if milter.GetDebug() {
 			logger.Println("Helo callback not implemented")
+		}
+	}
+	// Check if Data method was implemented
+	if _, ok := milter.(checkForData); ok {
+		if milter.GetDebug() {
+			logger.Println("Data callback implemented")
+		}
+		C.setData(&smfilter)
+	} else {
+		if milter.GetDebug() {
+			logger.Println("Data callback not implemented")
 		}
 	}
 	// Check if EnvFrom method was implemented


### PR DESCRIPTION
This pull request adds support for intercepting the DATA message via a suitable callback. This message apparently wasn't present in early versions of the milter library or the original Milter specification, but recent versions of Sendmail provide the option to intercept the DATA command in the SMTP transaction.